### PR TITLE
Fix `accuracy_test = F.accuracy(x_test, t_test)`

### DIFF
--- a/ja/14_Basics_of_Chainer_ja.ipynb
+++ b/ja/14_Basics_of_Chainer_ja.ipynb
@@ -918,7 +918,7 @@
     }
    ],
    "source": [
-    "accuracy_test = F.accuracy(x_test, t_test)\n",
+    "accuracy_test = F.accuracy(y_test, t_test)\n",
     "accuracy_test.array"
    ]
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16191443/57983675-caa16e80-7a8f-11e9-9619-00b1a49abc71.png)
The code seems to contradict with the explanation.

This is pointed in [chainer-jp slack](https://chainer-jp.slack.com/archives/CHU8PK49E/p1558026647002100) originally.