### PR TITLE
Fix URL

### DIFF
--- a/ja/01_Welcome_to_Chainer_Tutorial.ipynb
+++ b/ja/01_Welcome_to_Chainer_Tutorial.ipynb
@@ -104,7 +104,7 @@
     "\n",
     "このチュートリアルの一部の章には、`Open in Colab` と書かれた以下のようなボタンがページ上部に設置されています。\n",
     "\n",
-    "[![open in colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chainer/tutorials/blob/master/ja/01_Welcome_to_Chainer_Tutorial_ja.ipynb)\n",
+    "[![open in colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chainer/tutorials/blob/master/ja/01_Welcome_to_Chainer_Tutorial.ipynb)\n",
     "\n",
     "このボタンを押すと、ブラウザで見ている資料が、Colab 上で  Jupyter Notebook として開かれます。\n",
     "すると、チュートリアルの中で説明に用いられているコードを、**実際に実行して結果を確認することができます。**\n",


### PR DESCRIPTION
https://github.com/chainer/tutorials/blob/master/ja/01_Welcome_to_Chainer_Tutorial.ipynb

のページ中央付近の`Open in Colab`ボタンのリンク先が誤っていたので修正しました。